### PR TITLE
Remove eval-when-compile for using cl functions

### DIFF
--- a/historyf.el
+++ b/historyf.el
@@ -65,8 +65,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 (defgroup historyf nil
   "File history like browser"


### PR DESCRIPTION
This package uses not only cl macros, but also cl functions.
So eval-when-compile should be removed.